### PR TITLE
fixing concurrent update exception in stream source

### DIFF
--- a/core/redis-kafka-connect/src/main/java/com/redis/kafka/connect/source/RedisStreamSourceTask.java
+++ b/core/redis-kafka-connect/src/main/java/com/redis/kafka/connect/source/RedisStreamSourceTask.java
@@ -111,17 +111,22 @@ public class RedisStreamSourceTask extends SourceTask {
 	public void commitRecord(SourceRecord sourceRecord, RecordMetadata metadata) throws InterruptedException {
 		Map<String, ?> currentOffset = sourceRecord.sourceOffset();
 		if (currentOffset != null) {
-			sourceOffsets.add(currentOffset);
+			synchronized (sourceOffsets) {
+				sourceOffsets.add(currentOffset);
+			}
 		}
 	}
 
 	@Override
 	public void commit() throws InterruptedException {
 		if (reader != null) {
-			String[] ids = sourceOffsets.stream().map(m -> (String) m.get(OFFSET_FIELD)).toArray(String[]::new);
 			try {
-				reader.ack(config.getStreamName(), ids);
-				sourceOffsets.clear();
+				synchronized (sourceOffsets) {
+					String[] ids =
+							sourceOffsets.stream().map(m -> (String) m.get(OFFSET_FIELD)).toArray(String[]::new);
+					reader.ack(config.getStreamName(), ids);
+					sourceOffsets.clear();
+				}
 			} catch (Exception e) {
 				throw new ConnectException("Could not ack offsets to Redis", e);
 			}


### PR DESCRIPTION
This pull request introduces thread-safety improvements to the offset management logic in the `RedisStreamSourceTask` class. The main change is the addition of synchronization blocks around accesses to the `sourceOffsets` collection, ensuring safe concurrent modifications and reads.

### Thread-safety improvements:
* Wrapped the addition of offsets to the `sourceOffsets` collection in a `synchronized` block within the `commitRecord` method to prevent race conditions when multiple threads add offsets.
* Wrapped the reading, acknowledgment, and clearing of the `sourceOffsets` collection in a `synchronized` block within the `commit` method to ensure atomicity and consistency during offset commit operations.

```java
java.util.concurrent.ExecutionException: java.util.ConcurrentModificationException
	at java.base/java.util.concurrent.FutureTask.report(FutureTask.java:122)
	at java.base/java.util.concurrent.FutureTask.get(FutureTask.java:205)
	at org.apache.kafka.connect.runtime.AbstractWorkerSourceTask.commitSourceTask(AbstractWorkerSourceTask.java:636)
	at org.apache.kafka.connect.runtime.WorkerSourceTask.commitOffsets(WorkerSourceTask.java:326)
	at org.apache.kafka.connect.runtime.SourceTaskOffsetCommitter.commit(SourceTaskOffsetCommitter.java:111)
	at org.apache.kafka.connect.runtime.SourceTaskOffsetCommitter.lambda$schedule$0(SourceTaskOffsetCommitter.java:79)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:572)
	at java.base/java.util.concurrent.FutureTask.runAndReset(FutureTask.java:358)
	at java.base/java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:305)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642)
	at java.base/java.lang.Thread.run(Thread.java:1583)
Caused by: java.util.ConcurrentModificationException
	at java.base/java.util.ArrayList$ArrayListSpliterator.forEachRemaining(ArrayList.java:1714)
	at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:509)
	at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:499)
	at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:575)
	at java.base/java.util.stream.AbstractPipeline.evaluateToArrayNode(AbstractPipeline.java:260)
	at java.base/java.util.stream.ReferencePipeline.toArray(ReferencePipeline.java:616)
	at com.redis.kafka.connect.source.RedisStreamSourceTask.commit(RedisStreamSourceTask.java:121)
	at org.apache.kafka.connect.runtime.AbstractWorkerSourceTask.lambda$commitSourceTask$11(AbstractWorkerSourceTask.java:630)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:572)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:317)
	... 3 more```