### PR TITLE
fixing memory leak in keys source connector

### DIFF
--- a/core/redis-kafka-connect/src/main/java/com/redis/kafka/connect/source/RedisKeysSourceTask.java
+++ b/core/redis-kafka-connect/src/main/java/com/redis/kafka/connect/source/RedisKeysSourceTask.java
@@ -41,11 +41,6 @@ public class RedisKeysSourceTask extends SourceTask {
 
 	public static final Schema KEY_SCHEMA = Schema.STRING_SCHEMA;
 
-	/**
-	 * The offsets that have been processed and that are to be acknowledged by the
-	 * reader in {@link RedisKeysSourceTask#commit()}.
-	 */
-	private final List<Map<String, ?>> sourceOffsets = new ArrayList<>();
 	private final ToStructFunction converter = new ToStructFunction();
 	private final Clock clock;
 
@@ -96,22 +91,15 @@ public class RedisKeysSourceTask extends SourceTask {
 		}
 	}
 
-	private void addSourceOffset(Map<String, ?> sourceOffset) {
-		sourceOffsets.add(sourceOffset);
-	}
-
 	@Deprecated
 	@Override
 	public void commitRecord(SourceRecord sourceRecord) throws InterruptedException {
-		Map<String, ?> currentOffset = sourceRecord.sourceOffset();
-		if (currentOffset != null) {
-			addSourceOffset(currentOffset);
-		}
+		super.commitRecord(sourceRecord);
 	}
 
 	@Override
 	public void commit() throws InterruptedException {
-		// do nothing
+		super.commit();
 	}
 
 	@Override

--- a/core/redis-kafka-connect/src/main/java/com/redis/kafka/connect/source/RedisKeysSourceTask.java
+++ b/core/redis-kafka-connect/src/main/java/com/redis/kafka/connect/source/RedisKeysSourceTask.java
@@ -91,6 +91,10 @@ public class RedisKeysSourceTask extends SourceTask {
 		}
 	}
 
+	/*
+	 * Why sourceOffsets implementation was removed?
+	 * Explained here - https://confluentinc.atlassian.net/browse/CC-36370
+	 */
 	@Deprecated
 	@Override
 	public void commitRecord(SourceRecord sourceRecord) throws InterruptedException {


### PR DESCRIPTION
### Problem
The `sourceOffsets` list in `RedisKeysSourceTask` was continuously growing without ever being cleared, causing a memory leak in long-running connectors.

### Root Cause
- `commitRecord()` method added offsets to the list via `addSourceOffset()`
- `commit()` method was a no-op and never cleared the list
- The collected offsets were never actually used for any functionality

### Solution
- Removed the unused `sourceOffsets` field and `addSourceOffset()` method
- Simplified `commitRecord()` to be a no-op with explanatory comment
- No functional impact since Redis key monitoring doesn't require offset acknowledgment

### Why This Is Safe
Unlike `RedisStreamSourceTask`, the keys source connector uses Redis keyspace notifications which are fire-and-forget events that don't require acknowledgment. The `RedisItemReader` in `LIVE` mode handles state internally, making offset tracking unnecessary.