### PR TITLE
fix(reader): implement retry logic for opening Redis reader

### DIFF
--- a/core/redis-kafka-connect/src/main/java/com/redis/kafka/connect/source/RedisKeysSourceTask.java
+++ b/core/redis-kafka-connect/src/main/java/com/redis/kafka/connect/source/RedisKeysSourceTask.java
@@ -102,7 +102,7 @@ public class RedisKeysSourceTask extends SourceTask {
 						Thread.sleep(RETRY_DELAY_MS);
 					} catch (InterruptedException ie) {
 						Thread.currentThread().interrupt();
-						throw new ConnectException("Interrupted while retrying reader open", e);
+						throw new ConnectException("Interrupted while retrying reader open", ie);
 					}
 				}
 			}
@@ -134,9 +134,13 @@ public class RedisKeysSourceTask extends SourceTask {
 		if (client != null) {
 			try {
 				client.shutdown();
-				client.getResources().shutdown();
 			} catch (Exception e) {
 				log.warn("Error shutting down Redis client", e);
+			}
+			try {
+				client.getResources().shutdown();
+			} catch (Exception e) {
+				log.warn("Error shutting down Redis client resources", e);
 			}
 			client = null;
 		}

--- a/core/redis-kafka-connect/src/main/java/com/redis/kafka/connect/source/RedisKeysSourceTask.java
+++ b/core/redis-kafka-connect/src/main/java/com/redis/kafka/connect/source/RedisKeysSourceTask.java
@@ -95,6 +95,11 @@ public class RedisKeysSourceTask extends SourceTask {
 				return;
 			} catch (ItemStreamException e) {
 				lastException = e;
+				try {
+					reader.close();
+				} catch (Exception ce) {
+					log.debug("Error closing reader after failed open attempt", ce);
+				}
 				if (attempt < MAX_OPEN_RETRIES) {
 					log.warn("Failed to open reader (attempt {}/{}), retrying in {}ms",
 							attempt, MAX_OPEN_RETRIES, RETRY_DELAY_MS, e);

--- a/core/redis-kafka-connect/src/main/java/com/redis/kafka/connect/source/RedisKeysSourceTask.java
+++ b/core/redis-kafka-connect/src/main/java/com/redis/kafka/connect/source/RedisKeysSourceTask.java
@@ -21,7 +21,6 @@ import com.redis.spring.batch.item.redis.common.KeyValue;
 import io.lettuce.core.AbstractRedisClient;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.errors.ConnectException;
-import org.apache.kafka.connect.errors.RetriableException;
 import org.apache.kafka.connect.source.SourceRecord;
 import org.apache.kafka.connect.source.SourceTask;
 import org.springframework.batch.item.ExecutionContext;
@@ -30,7 +29,15 @@ import org.springframework.batch.item.ItemStreamException;
 import java.time.Clock;
 import java.util.*;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 public class RedisKeysSourceTask extends SourceTask {
+
+	private static final Logger log = LoggerFactory.getLogger(RedisKeysSourceTask.class);
+
+	static final int MAX_OPEN_RETRIES = 3;
+	static final long RETRY_DELAY_MS = 1000;
 
 	public static final Schema KEY_SCHEMA = Schema.STRING_SCHEMA;
 
@@ -77,11 +84,30 @@ public class RedisKeysSourceTask extends SourceTask {
 		if (!config.getIdleTimeout().isNegative() && !config.getIdleTimeout().isZero()) {
 			reader.setIdleTimeout(config.getIdleTimeout());
 		}
-		try {
-			reader.open(new ExecutionContext());
-		} catch (ItemStreamException e) {
-			throw new RetriableException("Could not open reader", e);
+		openReaderWithRetry();
+	}
+
+	private void openReaderWithRetry() {
+		ItemStreamException lastException = null;
+		for (int attempt = 1; attempt <= MAX_OPEN_RETRIES; attempt++) {
+			try {
+				reader.open(new ExecutionContext());
+				return;
+			} catch (ItemStreamException e) {
+				lastException = e;
+				if (attempt < MAX_OPEN_RETRIES) {
+					log.warn("Failed to open reader (attempt {}/{}), retrying in {}ms",
+							attempt, MAX_OPEN_RETRIES, RETRY_DELAY_MS, e);
+					try {
+						Thread.sleep(RETRY_DELAY_MS);
+					} catch (InterruptedException ie) {
+						Thread.currentThread().interrupt();
+						throw new ConnectException("Interrupted while retrying reader open", e);
+					}
+				}
+			}
 		}
+		throw new ConnectException("Could not open reader after " + MAX_OPEN_RETRIES + " attempts", lastException);
 	}
 
 	@Deprecated
@@ -98,12 +124,20 @@ public class RedisKeysSourceTask extends SourceTask {
 	@Override
 	public void stop() {
 		if (reader != null) {
-			reader.close();
+			try {
+				reader.close();
+			} catch (Exception e) {
+				log.warn("Error closing reader", e);
+			}
 			reader = null;
 		}
 		if (client != null) {
-			client.shutdown();
-			client.getResources().shutdown();
+			try {
+				client.shutdown();
+				client.getResources().shutdown();
+			} catch (Exception e) {
+				log.warn("Error shutting down Redis client", e);
+			}
 			client = null;
 		}
 	}


### PR DESCRIPTION
## Summary

- Add retry logic (3 attempts, 1s backoff) around `reader.open()` in `RedisKeysSourceTask.start()` to handle transient `ConcurrentModificationException` from `spring-batch-redis`'s `JobUtils.hsqldbDataSource()` — the static `HashMap.computeIfAbsent` is not thread-safe on Java 9+
- Replace `RetriableException` with `ConnectException` after exhausting retries, since `RetriableException` has no effect during task startup (Connect treats it as unrecoverable and kills the task)
- Wrap `reader.close()` and `client.shutdown()` in try-catch in `stop()` to prevent zombie connectors when cleanup fails on partially-initialized state

## Context

In production, a single keys source connector (`lcc-99wr75`) entered a 2+ week death spiral:
1. `ConcurrentModificationException` in `HashMap.computeIfAbsent` during `reader.open()` → task killed as "unrecoverable"
2. Restart attempts fail because the task can't be gracefully stopped (reader/client cleanup throws)
3. Connector becomes unresponsive zombie, consuming resources indefinitely

The root cause is in `spring-batch-redis-infrastructure` (tested 4.6.2 and 4.8.0) — `JobUtils.dataSources` is a plain `HashMap` instead of `ConcurrentHashMap`. This fix works around the upstream bug.